### PR TITLE
fix SQLSRV throws for method_exists()

### DIFF
--- a/Store/PdoStore.php
+++ b/Store/PdoStore.php
@@ -313,7 +313,8 @@ class PdoStore implements StoreInterface
         $sql = "DELETE FROM $this->table WHERE $this->expirationCol <= {$this->getCurrentTimestampStatement()}";
 
         $conn = $this->getConnection();
-        if (method_exists($conn, 'executeStatement')) {
+
+        if (!$conn instanceof \PDO && method_exists($conn, 'executeStatement')) {
             $conn->executeStatement($sql);
         } else {
             $conn->exec($sql);


### PR DESCRIPTION
pdo_sqlsrv driver 5.9.0 on mac throws an exception for any call on method_exists().
(see microsoft/msphpsql/issues/1306)
executeStatement() is a DBAL-method, exec() is PDO.
exclude method_exists() check for PDO type of connections